### PR TITLE
fix: #38 Autoupdate crush bug

### DIFF
--- a/src/Plugins/System/AppUpdate/Linux/AppImageAutoUpdater.cpp
+++ b/src/Plugins/System/AppUpdate/Linux/AppImageAutoUpdater.cpp
@@ -71,7 +71,11 @@ void AppImageAutoUpdater::checkForUpdatesInBackground()
     if (updater) {
         auto t = std::thread([this, updater]() {
             bool updateAvailable = false;
-            updater->checkForChanges(updateAvailable);
+            try {
+                updater->checkForChanges(updateAvailable);
+            } catch (const std::exception &e) {
+                apxMsgW() << tr("Error while checking for updates: ") << e.what();
+            }
             if (updateAvailable) {
                 setState(UpdateAvailable);
                 trigger();


### PR DESCRIPTION
Originally, I attempted to convince the program that it was a bundle, but in the end, I had to run the AppImage and attach GDB directly to the process because GDB refused to launch the AppImage directly. Ultimately, I was able to trace back the issue; the exception was thrown from the libappimageupdate library after the checkForChanges function call.

Solution: Wrap the function call in a try-catch block; no further actions are required. The AppUpdate plugin will be in the "NoUpdates" state.