### PR TITLE
fix: #11 Access modifiers order fix

### DIFF
--- a/src/lib/ApxCore/App/App.h
+++ b/src/lib/ApxCore/App/App.h
@@ -86,6 +86,37 @@ public:
 
     static AppPlugin *plugin(QString name);
 
+public:
+    AppEngine *engine() const;
+
+    QQuickWindow *window() const;
+    double scale() const;
+    void setScale(double v);
+
+    AppLog *appLog() const;
+    AppNotify *appNotify() const;
+    AppNotifyListModel *notifyModel() const;
+
+    AppPrefs *prefs() const;
+
+    QString lang() const;
+
+protected:
+    AppRoot *f_apx;
+
+    virtual void loadFonts();
+    virtual void loadServices();
+
+protected:
+    AppEngine *m_engine;
+    QQuickWindow *m_window;
+    double m_scale;
+    AppNotify *m_appNotify;
+    AppNotifyListModel *m_notifyModel;
+    AppLog *m_appLog;
+    AppPrefs *m_prefs;
+    QString m_lang;
+
 private:
     static App *_instance;
 
@@ -99,12 +130,6 @@ private:
 
     void loadTranslations();
     void loadTranslator(const QString &fileName);
-
-protected:
-    AppRoot *f_apx;
-
-    virtual void loadFonts();
-    virtual void loadServices();
 
 private slots:
     void appStateChanged(Qt::ApplicationState state);
@@ -132,33 +157,6 @@ signals:
     void about();
 
     void appQuit();
-
-    //---------------------------------------
-    //PROPERTIES
-public:
-    AppEngine *engine() const;
-
-    QQuickWindow *window() const;
-    double scale() const;
-    void setScale(double v);
-
-    AppLog *appLog() const;
-    AppNotify *appNotify() const;
-    AppNotifyListModel *notifyModel() const;
-
-    AppPrefs *prefs() const;
-
-    QString lang() const;
-
-protected:
-    AppEngine *m_engine;
-    QQuickWindow *m_window;
-    double m_scale;
-    AppNotify *m_appNotify;
-    AppNotifyListModel *m_notifyModel;
-    AppLog *m_appLog;
-    AppPrefs *m_prefs;
-    QString m_lang;
 
 signals:
     void windowChanged();

--- a/src/lib/ApxCore/App/AppBase.h
+++ b/src/lib/ApxCore/App/AppBase.h
@@ -1,3 +1,4 @@
+
 /*
  * APX Autopilot project <http://docs.uavos.com>
  *

--- a/src/lib/ApxCore/App/AppNotifyListModel.h
+++ b/src/lib/ApxCore/App/AppNotifyListModel.h
@@ -66,13 +66,10 @@ public:
     };
     QList<NotifyListItem *> m_items;
 
-private slots:
-    void notification(QString msg, QString subsystem, AppNotify::NotifyFlags flags, Fact *fact);
-
-    //-----------------------------------------
-    //PROPERTIES
-public:
 protected:
 signals:
     void countChanged();
+
+private slots:
+    void notification(QString msg, QString subsystem, AppNotify::NotifyFlags flags, Fact *fact);
 };

--- a/src/lib/ApxCore/App/AppRoot.h
+++ b/src/lib/ApxCore/App/AppRoot.h
@@ -49,10 +49,6 @@ public:
     //global progress
     void updateProgress(Fact *fact);
 
-private:
-    static AppRoot *_instance;
-    QList<QPointer<Fact>> progressList;
-
     //----------------------------------
     // static helpers and data converters
 public:
@@ -93,6 +89,10 @@ public:
 
 public:
     Q_INVOKABLE static void sound(const QString &v);
+
+private:
+    static AppRoot *_instance;
+    QList<QPointer<Fact>> progressList;
 
 signals:
     void factTriggered(Fact *fact, QVariantMap opts);

--- a/src/lib/ApxCore/Fact/Fact.h
+++ b/src/lib/ApxCore/Fact/Fact.h
@@ -139,31 +139,6 @@ public:
     virtual QString mandalaToString(quint16 pid_raw) const override;
     virtual quint16 stringToMandala(const QString &s) const override;
 
-private:
-    Fact *m_mandala{nullptr};
-
-    int m_progress_s{0};
-
-private:
-    QString pTitle() const;
-
-    void updateBinding(Fact *src);
-
-private slots:
-    void updateModels();
-    void onOptionsChanged();
-    void trackProgress();
-
-public slots:
-    //trigger fact from UI (f.ex. to display menu)
-    void trigger(QVariantMap opts = QVariantMap());
-
-signals:
-    void triggered(QVariantMap opts);
-    void menuBack();
-
-    //---------------------------------------
-    // PROPERTIES
 public:
     FactBase::Flags flags() const;
     void setFlags(FactBase::Flags v);
@@ -222,6 +197,36 @@ protected:
 
     int m_scnt{0};
 
+private:
+    Fact *m_mandala{nullptr};
+
+    int m_progress_s{0};
+
+private:
+    QString pTitle() const;
+
+    void updateBinding(Fact *src);
+
+    //tree properties propagate
+private:
+    bool m_parentEnabled{true};
+    void updateParentEnabled();
+    bool m_parentVisible{true};
+    void updateParentVisible();
+
+private slots:
+    void updateModels();
+    void onOptionsChanged();
+    void trackProgress();
+
+public slots:
+    //trigger fact from UI (f.ex. to display menu)
+    void trigger(QVariantMap opts = QVariantMap());
+
+signals:
+    void triggered(QVariantMap opts);
+    void menuBack();
+
 signals:
     void flagsChanged();
 
@@ -244,11 +249,4 @@ signals:
     void optsChanged();
 
     void scntChanged();
-
-    //tree properties propagate
-private:
-    bool m_parentEnabled{true};
-    void updateParentEnabled();
-    bool m_parentVisible{true};
-    void updateParentVisible();
 };

--- a/src/lib/ApxCore/Fact/FactBase.h
+++ b/src/lib/ApxCore/Fact/FactBase.h
@@ -123,41 +123,6 @@ public:
     Q_INVOKABLE QString jsname() const;
     Q_INVOKABLE QString jspath() const;
 
-public slots:
-    void deleteFact();
-    void deleteChildren();
-
-signals:
-    //tree structure change signals for models
-    void itemToBeInserted(int row, FactBase *item);
-    void itemInserted(FactBase *item);
-    void itemToBeRemoved(int row, FactBase *item);
-    void itemRemoved(FactBase *item);
-    void itemToBeMoved(int row, int dest, FactBase *item);
-    void itemMoved(FactBase *item);
-
-    void actionsUpdated();
-
-    void removed();
-
-private:
-    FactList m_facts;
-    FactList m_actions;
-
-    void addChild(Fact *item);
-    void removeChild(Fact *item);
-    void moveChild(Fact *item, int n, bool safeMode = false);
-
-    void updateNum();
-    void updateSize();
-    void updateChildrenNums();
-
-    void updatePath();
-
-    QList<FactPropertyBinding *> _property_binds;
-
-    //-----------------------------------------
-    //PROPERTIES
 public:
     FactBase::Flag treeType() const;
     void setTreeType(FactBase::Flag v);
@@ -183,6 +148,39 @@ protected:
 
     int m_size{0};
     int m_num{0};
+
+private:
+    FactList m_facts;
+    FactList m_actions;
+
+    void addChild(Fact *item);
+    void removeChild(Fact *item);
+    void moveChild(Fact *item, int n, bool safeMode = false);
+
+    void updateNum();
+    void updateSize();
+    void updateChildrenNums();
+
+    void updatePath();
+
+    QList<FactPropertyBinding *> _property_binds;
+
+public slots:
+    void deleteFact();
+    void deleteChildren();
+
+signals:
+    //tree structure change signals for models
+    void itemToBeInserted(int row, FactBase *item);
+    void itemInserted(FactBase *item);
+    void itemToBeRemoved(int row, FactBase *item);
+    void itemRemoved(FactBase *item);
+    void itemToBeMoved(int row, int dest, FactBase *item);
+    void itemMoved(FactBase *item);
+
+    void actionsUpdated();
+
+    void removed();
 
 signals:
     void treeTypeChanged();

--- a/src/lib/ApxCore/Fact/FactData.h
+++ b/src/lib/ApxCore/Fact/FactData.h
@@ -81,32 +81,10 @@ public slots:
     virtual void restore();
     void restoreDefaults();
 
-protected:
-    bool updateValue(const QVariant &v);
-    void updateValueText();
-    void updateText();
-
-    virtual QString toText(const QVariant &v) const;
-
-    QString prefsGroup() const;
-
-    static int _string_to_bool(QString s);
-    static int _string_to_int(const QString &s);
-    static bool _check_type(const QVariant &v, QMetaType::Type t);
-    static bool _check_int(const QVariant &v);
-
-    QVariant _type_value(const QVariant &v) const;
-    QString _string_with_units(const QString &v) const;
-
-private slots:
-    void getPresistentValue();
-
 public slots:
     void savePresistentValue();
     void loadPresistentValue();
 
-    //---------------------------------------
-    // PROPERTIES
 public:
     FactBase::Flag dataType() const;
     void setDataType(FactBase::Flag v);
@@ -154,6 +132,23 @@ public:
     void setDefaultValue(const QVariant &v);
 
 protected:
+    bool updateValue(const QVariant &v);
+    void updateValueText();
+    void updateText();
+
+    virtual QString toText(const QVariant &v) const;
+
+    QString prefsGroup() const;
+
+    static int _string_to_bool(QString s);
+    static int _string_to_int(const QString &s);
+    static bool _check_type(const QVariant &v, QMetaType::Type t);
+    static bool _check_int(const QVariant &v);
+
+    QVariant _type_value(const QVariant &v) const;
+    QString _string_with_units(const QString &v) const;
+
+protected:
     Flag m_dataType{NoFlags};
 
     QVariant m_value;
@@ -181,6 +176,12 @@ protected:
     QString m_units;
 
     QVariant m_defaultValue;
+
+private slots:
+    void getPresistentValue();
+
+    //---------------------------------------
+    // PROPERTIES
 
 signals:
     void dataTypeChanged();

--- a/src/lib/ApxCore/Fact/FactListModel.h
+++ b/src/lib/ApxCore/Fact/FactListModel.h
@@ -39,13 +39,13 @@ public:
 
     QHash<int, QByteArray> roleNames() const;
 
-public slots:
-    void sync();
-    void scheduleSync();
-    void resetFilter();
+public:
+    Q_INVOKABLE Fact *get(int i) const;
 
-private:
-    QTimer *syncTimer;
+public:
+    int count() const;
+    QString filter() const;
+    void setFilter(QString v);
 
 protected:
     Fact *fact;
@@ -61,18 +61,17 @@ protected:
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole);
 
-public:
-    Q_INVOKABLE Fact *get(int i) const;
-
-    //-----------------------------------------
-    //PROPERTIES
-public:
-    int count() const;
-    QString filter() const;
-    void setFilter(QString v);
-
 private:
     QString m_filter;
+
+private:
+    QTimer *syncTimer;
+
+public slots:
+    void sync();
+    void scheduleSync();
+    void resetFilter();
+
 signals:
     void countChanged();
     void filterChanged();

--- a/src/lib/ApxData/Database/DatabaseLookupModel.h
+++ b/src/lib/ApxData/Database/DatabaseLookupModel.h
@@ -44,6 +44,15 @@ public:
 
     int indexOf(const QString &name, const QVariant &value) const;
 
+public:
+    Q_INVOKABLE QVariantMap get(int i) const;
+    Q_INVOKABLE bool set(int i, QVariantMap v);
+
+public:
+    int count() const;
+    QString filter() const;
+    void setFilter(QString v);
+
 protected:
     ItemsList _items;
     QList<quint64> keys;
@@ -52,9 +61,8 @@ protected:
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
 
-public:
-    Q_INVOKABLE QVariantMap get(int i) const;
-    Q_INVOKABLE bool set(int i, QVariantMap v);
+private:
+    QString m_filter;
 
 public slots:
     void syncItems(ItemsList list);
@@ -65,15 +73,6 @@ signals:
     void itemRemoved(int i, QVariantMap v);
     void synced();
 
-    //-----------------------------------------
-    //PROPERTIES
-public:
-    int count() const;
-    QString filter() const;
-    void setFilter(QString v);
-
-private:
-    QString m_filter;
 signals:
     void countChanged();
     void filterChanged();

--- a/src/lib/ApxData/Database/DatabaseSession.h
+++ b/src/lib/ApxData/Database/DatabaseSession.h
@@ -64,6 +64,17 @@ public:
     QStringList tableFields(QString tableName) const;
     void updateTableFields(const QString tableName, QStringList fields);
 
+public:
+    quint64 capacity() const;
+
+protected:
+    quint64 m_capacity;
+
+protected:
+    Database *database;
+    DatabaseWorker *m_worker;
+    QReadWriteLock m_workerLock;
+
 private:
     QTimer modifiedTimer;
 
@@ -71,11 +82,6 @@ private:
     int infoQueueSize;
 
     QHash<QString, QStringList> _tableFields;
-
-protected:
-    Database *database;
-    DatabaseWorker *m_worker;
-    QReadWriteLock m_workerLock;
 
 private slots:
     void updateInfo();
@@ -92,13 +98,6 @@ public slots:
 signals:
     void modified();
 
-    //-----------------------------------------
-    //PROPERTIES
-public:
-    quint64 capacity() const;
-
-protected:
-    quint64 m_capacity;
 signals:
     void capacityChanged();
 };
@@ -119,13 +118,13 @@ public:
         exec();
     }
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     QString tableName;
     QStringList fields;
     QString tail;
-
-protected:
-    bool run(QSqlQuery &query);
 };
 class DBReqMakeIndex : public DatabaseRequest
 {
@@ -143,13 +142,13 @@ public:
         exec();
     }
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     QString tableName;
     QString indexName;
     bool unique;
-
-protected:
-    bool run(QSqlQuery &query);
 };
 class DBReqVacuum : public DatabaseRequest
 {
@@ -160,11 +159,11 @@ public:
         , name(QFileInfo(db->fileName).baseName())
     {}
 
-private:
-    QString name;
-
 protected:
     bool run(QSqlQuery &query);
+
+private:
+    QString name;
 };
 class DBReqAnalyze : public DatabaseRequest
 {
@@ -175,9 +174,9 @@ public:
         , name(QFileInfo(db->fileName).baseName())
     {}
 
-private:
-    QString name;
-
 protected:
     bool run(QSqlQuery &query);
+
+private:
+    QString name;
 };

--- a/src/lib/ApxData/Database/MissionsDB.h
+++ b/src/lib/ApxData/Database/MissionsDB.h
@@ -119,14 +119,15 @@ public:
         , key(key)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     QString title;
     double lat;
     double lon;
     quint64 key;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void siteAdded(QString title);
     void siteModified(QString title);
@@ -140,11 +141,12 @@ public:
         , key(key)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     quint64 key;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void siteRemoved();
 };

--- a/src/lib/ApxData/Database/TelemetryDB.h
+++ b/src/lib/ApxData/Database/TelemetryDB.h
@@ -88,11 +88,12 @@ public:
         , records(records)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     Records records;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void progress(int v);
 };

--- a/src/lib/ApxData/Database/TelemetryReqRead.h
+++ b/src/lib/ApxData/Database/TelemetryReqRead.h
@@ -118,12 +118,13 @@ public:
         , time(time)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     quint64 cacheID;
     quint64 time;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void eventsLoaded(DatabaseRequest::Records records);
 };
@@ -139,13 +140,14 @@ public:
         , name(name)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     quint64 cacheID;
     quint64 time;
     QString name;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void eventLoaded(QString value, QString uid, bool uplink);
 };
@@ -160,12 +162,13 @@ public:
         , time(time)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     quint64 cacheID;
     quint64 time;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void confLoaded(DatabaseRequest::Records records);
 };
@@ -223,11 +226,12 @@ public:
         , telemetryID(telemetryID)
     {}
 
+protected:
+    bool run(QSqlQuery &query);
+
 private:
     quint64 telemetryID;
 
-protected:
-    bool run(QSqlQuery &query);
 signals:
     void deletedID(quint64 telemetryID);
 };

--- a/src/lib/ApxData/Mandala/Mandala.h
+++ b/src/lib/ApxData/Mandala/Mandala.h
@@ -45,17 +45,17 @@ public:
 
     void updateUsed(int adj);
 
+protected:
+    // Fact override
+    virtual QString mandalaToString(xbus::pid_raw_t pid_raw) const override;
+    virtual xbus::pid_raw_t stringToMandala(const QString &s) const override;
+
 private:
     QMap<mandala::uid_t, MandalaFact *> _uid_map;
     QList<MandalaFact *> _valueFacts;
 
     uint _total{};
     uint _used{};
-
-protected:
-    // Fact override
-    virtual QString mandalaToString(xbus::pid_raw_t pid_raw) const override;
-    virtual xbus::pid_raw_t stringToMandala(const QString &s) const override;
 
 private slots:
     void recordSendValue(mandala::uid_t uid, QVariant value);

--- a/src/lib/ApxData/Mandala/MandalaFact.h
+++ b/src/lib/ApxData/Mandala/MandalaFact.h
@@ -59,6 +59,15 @@ public:
 
     inline const mandala::meta_s &meta() const { return m_meta; }
 
+public:
+    bool isSystem() const;
+    bool isGroup() const;
+
+protected:
+    //Fact override
+    virtual QVariant data(int col, int role) override;
+    virtual bool showThis(QRegExp re) const override; //filter helper
+
 private:
     Mandala *m_tree;
     const mandala::meta_s &m_meta;
@@ -80,15 +89,4 @@ private:
 
     QVariant convertFromStream(const QVariant &v) const;
     QVariant convertForStream(const QVariant &v) const;
-
-protected:
-    //Fact override
-    virtual QVariant data(int col, int role) override;
-    virtual bool showThis(QRegExp re) const override; //filter helper
-
-    //---------------------------------------
-    // PROPERTIES
-public:
-    bool isSystem() const;
-    bool isGroup() const;
 };

--- a/src/lib/ApxData/Protocols/PBase.h
+++ b/src/lib/ApxData/Protocols/PBase.h
@@ -50,11 +50,11 @@ public:
     // interface to node firmware loader
     PFirmware *firmware() const { return m_firmware; }
 
-private:
-    PTrace *_trace;
-
 protected:
     PFirmware *m_firmware{};
+
+private:
+    PTrace *_trace;
 
     // data comm
 public slots:

--- a/src/lib/ApxData/Protocols/PFirmware.h
+++ b/src/lib/ApxData/Protocols/PFirmware.h
@@ -44,9 +44,6 @@ public:
 
     virtual void upgradeFirmware(QString uid, QString name, QByteArray data, quint32 offset);
 
-private:
-    bool m_upgrading{};
-
 protected:
     QString _uid;
     QString _name;
@@ -54,6 +51,9 @@ protected:
     quint32 _offset;
 
     bool _success{};
+
+private:
+    bool m_upgrading{};
 
 protected slots:
     virtual void finish();

--- a/src/lib/ApxData/Protocols/PTrace.h
+++ b/src/lib/ApxData/Protocols/PTrace.h
@@ -55,11 +55,11 @@ public:
         data(QByteArray(reinterpret_cast<const char *>(&r), sizeof(r)));
     }
 
-private:
-    QStringList _blocks;
-
 protected:
     bool _enabled{false};
+
+private:
+    QStringList _blocks;
 
 signals:
     void packet(QStringList blocks);


### PR DESCRIPTION
Improved readability of GCS code by reorganizing class headers.

Reordering class headers, placing public methods and properties together at the top of the class for better clarity.