### PR TITLE
Add datalink mode for remote serial port via ethernet

### DIFF
--- a/src/lib/ApxGcs/Datalink/Datalink.cpp
+++ b/src/lib/ApxGcs/Datalink/Datalink.cpp
@@ -63,6 +63,8 @@ Datalink::Datalink(Fact *parent)
     f_server->setSection(sect);
     f_remotes = new DatalinkRemotes(this);
     f_remotes->setSection(sect);
+    f_serialRemotes = new DatalinkSerialRemotes(this);
+    f_serialRemotes->setSection(sect);
     f_ports = new DatalinkPorts(this);
     f_ports->setSection(sect);
 

--- a/src/lib/ApxGcs/Datalink/Datalink.h
+++ b/src/lib/ApxGcs/Datalink/Datalink.h
@@ -24,6 +24,7 @@
 #include "DatalinkConnection.h"
 #include "DatalinkPorts.h"
 #include "DatalinkRemotes.h"
+#include "DatalinkSerialRemotes.h"
 #include "DatalinkServer.h"
 #include "DatalinkStats.h"
 #include <Fact/Fact.h>
@@ -55,6 +56,7 @@ public:
     Fact *f_readonly;
     DatalinkServer *f_server;
     DatalinkRemotes *f_remotes;
+    DatalinkSerialRemotes *f_serialRemotes;
     DatalinkPorts *f_ports;
 
     Protocols *f_protocols;

--- a/src/lib/ApxGcs/Datalink/DatalinkSerialRemote.cpp
+++ b/src/lib/ApxGcs/Datalink/DatalinkSerialRemote.cpp
@@ -1,0 +1,157 @@
+/*
+ * APX Autopilot project <http://docs.uavos.com>
+ *
+ * Copyright (c) 2003-2020, Aliaksei Stratsilatau <sa@uavos.com>
+ * All rights reserved
+ *
+ * This file is part of APX Ground Control.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "DatalinkSerialRemote.h"
+#include "Datalink.h"
+
+#include <App/App.h>
+#include <App/AppLog.h>
+
+DatalinkSerialRemote::DatalinkSerialRemote(Fact *parent, QString host, int port)
+    : DatalinkConnection(parent,
+                         "remote_serial#",
+                         QString("%1:%2").arg(host).arg(port),
+                         "",
+                         Datalink::CLIENTS | Datalink::LOCAL,
+                         Datalink::CLIENTS | Datalink::LOCAL)
+    , m_host(host)
+    , m_port(port)
+{
+    f_state = new Fact(this, "state", tr("Unconnected"), "");
+    f_remove = new Fact(this, "remove", tr("Remove"), "", Action | Remove | CloseOnTrigger);
+
+    m_noDataTimer.setSingleShot(true);
+    m_noDataTimer.setInterval(3000);
+    connect(&m_socket, &QTcpSocket::errorOccurred, this, &DatalinkSerialRemote::onErrorOccured);
+    connect(&m_socket, &QTcpSocket::stateChanged, this, &DatalinkSerialRemote::onStateChanged);
+    connect(&m_socket, &QTcpSocket::readyRead, this, &DatalinkSerialRemote::readDataAvailable);
+    connect(&m_socket, &QTcpSocket::readyRead, &m_noDataTimer, qOverload<>(&QTimer::start));
+    connect(&m_noDataTimer, &QTimer::timeout, this, &DatalinkSerialRemote::onNoDataTimerTimeout);
+    connect(this,
+            &DatalinkConnection::activatedChanged,
+            this,
+            &DatalinkSerialRemote::onActivatedChanged);
+    connect(f_remove, &Fact::triggered, this, &DatalinkSerialRemote::onRemoveTriggered);
+
+    setEncoder(&m_enc);
+    setDecoder(&m_dec);
+}
+
+QString DatalinkSerialRemote::getHost() const
+{
+    return m_host;
+}
+
+int DatalinkSerialRemote::getPort() const
+{
+    return m_port;
+}
+
+void DatalinkSerialRemote::onErrorOccured(QAbstractSocket::SocketError socketError)
+{
+    apxConsoleW() << "TCP error:" << m_socket.errorString();
+
+    if (m_socket.state() == QAbstractSocket::ConnectedState) {
+        m_socket.abort();
+        apxMsgW() << tr("TCP disconnected: %1").arg(m_host);
+    }
+}
+
+void DatalinkSerialRemote::onStateChanged(QAbstractSocket::SocketState socketState)
+{
+    QMap<QAbstractSocket::SocketState, QString> map
+        = {{QAbstractSocket::UnconnectedState, "Unconnected"},
+           {QAbstractSocket::HostLookupState, "Host lookup"},
+           {QAbstractSocket::ConnectingState, "Connecting"},
+           {QAbstractSocket::ConnectedState, "Connected"},
+           {QAbstractSocket::BoundState, "Bound"},
+           {QAbstractSocket::ClosingState, "Closing"}};
+    auto stateString = map.value(socketState, "Unknown state");
+    setDescr(stateString);
+    f_state->setTitle(stateString);
+    if (socketState == QAbstractSocket::ConnectedState) {
+        setActive(true);
+    } else {
+        setActive(false);
+    }
+}
+
+void DatalinkSerialRemote::onActivatedChanged()
+{
+    if (activated()) {
+        open();
+    } else {
+        close();
+    }
+}
+
+void DatalinkSerialRemote::onNoDataTimerTimeout()
+{
+    close();
+    if (activated()) {
+        open();
+    }
+}
+
+void DatalinkSerialRemote::onRemoveTriggered() 
+{
+    close();
+    setParentFact(nullptr);
+    deleteLater();
+}
+
+void DatalinkSerialRemote::open()
+{
+    if (!activated())
+        return;
+
+    m_socket.connectToHost(m_host, m_port);
+    m_noDataTimer.start();
+}
+
+void DatalinkSerialRemote::close()
+{
+    if (m_socket.state() == QAbstractSocket::ConnectedState) {
+        apxMsg() << tr("TCP connection closed: %1").arg(m_host);
+    }
+    m_socket.abort();
+    closed();
+}
+
+void DatalinkSerialRemote::write(const QByteArray &packet)
+{
+    if (m_socket.state() == QAbstractSocket::ConnectedState) {
+        auto bytesWritten = m_socket.write(packet);
+        if (bytesWritten >= 0 && bytesWritten != packet.size()) {
+            qWarning() << "TCP: Packet was not sent completely";
+        }
+    }
+}
+
+QByteArray DatalinkSerialRemote::read()
+{
+    if (m_socket.state() != QAbstractSocket::ConnectedState) {
+        resetDataStream();
+        return {};
+    }
+
+    return m_socket.readAll();
+}

--- a/src/lib/ApxGcs/Datalink/DatalinkSerialRemote.h
+++ b/src/lib/ApxGcs/Datalink/DatalinkSerialRemote.h
@@ -1,0 +1,63 @@
+/*
+ * APX Autopilot project <http://docs.uavos.com>
+ *
+ * Copyright (c) 2003-2020, Aliaksei Stratsilatau <sa@uavos.com>
+ * All rights reserved
+ *
+ * This file is part of APX Ground Control.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "DatalinkConnection.h"
+#include <serial/CobsDecoder.h>
+#include <serial/CobsEncoder.h>
+#include <QTcpSocket>
+
+class DatalinkSerialRemote : public DatalinkConnection
+{
+    Q_OBJECT
+
+public:
+    explicit DatalinkSerialRemote(Fact *parent, QString host, int port);
+
+    Fact *f_state = nullptr;
+    Fact *f_remove = nullptr;
+
+    QString getHost() const;
+    int getPort() const;
+
+protected:
+    //DatalinkConnection overrided
+    void open() override;
+    void close() override;
+    QByteArray read() override;
+    void write(const QByteArray &packet) override;
+
+private:
+    QString m_host;
+    int m_port;
+    QTcpSocket m_socket;
+    QTimer m_noDataTimer;
+    CobsDecoder<> m_dec;
+    CobsEncoder<> m_enc;
+
+private slots:
+    void onErrorOccured(QAbstractSocket::SocketError socketError);
+    void onStateChanged(QAbstractSocket::SocketState socketState);
+    void onActivatedChanged();
+    void onNoDataTimerTimeout();
+    void onRemoveTriggered();
+};

--- a/src/lib/ApxGcs/Datalink/DatalinkSerialRemotes.cpp
+++ b/src/lib/ApxGcs/Datalink/DatalinkSerialRemotes.cpp
@@ -1,0 +1,155 @@
+/*
+ * APX Autopilot project <http://docs.uavos.com>
+ *
+ * Copyright (c) 2003-2020, Aliaksei Stratsilatau <sa@uavos.com>
+ * All rights reserved
+ *
+ * This file is part of APX Ground Control.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include "DatalinkSerialRemotes.h"
+
+#include "Datalink.h"
+#include "DatalinkSerialRemote.h"
+#include <App/AppLog.h>
+#include <App/AppSettings.h>
+
+DatalinkSerialRemotes::DatalinkSerialRemotes(Datalink *datalink)
+    : Fact(datalink,
+           "remote_serials",
+           tr("Remote serial ports"),
+           "",
+           Group | FlatModel,
+           "serial-port")
+    , m_datalink(datalink)
+{
+    //connect to specific host menu
+    f_add = new Fact(this,
+                     "add",
+                     tr("Connect to remote serial port"),
+                     tr("Create new connection"),
+                     Group);
+    f_add->setIcon("plus");
+    f_host = new Fact(f_add,
+                      "host",
+                      tr("Host"),
+                      tr("TCP Address of remote serial port"),
+                      Text | PersistentValue,
+                      "domain");
+    f_port = new Fact(f_add,
+                      "port",
+                      tr("Port"),
+                      tr("TCP Port of remote serial port"),
+                      Int | PersistentValue,
+                      "numeric");
+    f_list = new Fact(this,
+                      "remote_ports",
+                      tr("Remote ports"),
+                      tr("Configured remote ports"),
+                      Section | Count);
+    f_connect = new Fact(f_add, "connect", tr("Connect"), "", Action | Apply | CloseOnTrigger);
+    connect(f_connect, &Fact::triggered, this, &DatalinkSerialRemotes::onConnectTriggered);
+
+    load();
+}
+
+void DatalinkSerialRemotes::updateStatus()
+{
+    int connectedCount = 0;
+    int totalCount = f_list->size();
+    for(auto f: f_list->facts()) {
+        if(f->active()) {
+            connectedCount++;
+        }
+    }
+    setValue(QString("%1/%2").arg(connectedCount).arg(totalCount));
+}
+
+void DatalinkSerialRemotes::load()
+{
+    QFile file(AppDirs::prefs().filePath("remote_ports.json"));
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+        QJsonDocument json = QJsonDocument::fromJson(file.readAll());
+        if (!json.isEmpty() && !json.isNull()) {
+            for (const auto &v : json.array()) {
+                auto o = v.toObject();
+                QString host = o["host"].toString();
+                int port = o["port"].toInt();
+                auto c = createConnection(host, port);
+                c->setActivated(o["activated"].toBool());
+            }
+        }
+    }
+}
+void DatalinkSerialRemotes::save()
+{
+    QFile file(AppDirs::prefs().filePath("remote_ports.json"));
+    if (file.open(QFile::WriteOnly | QFile::Text)) {
+        auto objs = f_list->facts();
+        QJsonArray array;
+        for (auto o : objs) {
+            auto c = qobject_cast<DatalinkSerialRemote *>(o);
+            if (c) {
+                QJsonObject json;
+                json["host"] = c->getHost();
+                json["port"] = c->getPort();
+                json["activated"] = c->activated();
+                array.append(json);
+            }
+        }
+        file.write(QJsonDocument(array).toJson());
+        file.close();
+    } else {
+        apxMsgW() << file.errorString();
+    }
+}
+
+DatalinkSerialRemote *DatalinkSerialRemotes::createConnection(const QString &host, int port)
+{
+    DatalinkSerialRemote *c = new DatalinkSerialRemote(f_list, host, port);
+    m_datalink->addConnection(c);
+    c->setValue(true);
+
+    connect(c,
+            &DatalinkSerialRemote::activeChanged,
+            this,
+            &DatalinkSerialRemotes::onConnectionActiveChanged);
+    connect(c, &DatalinkSerialRemote::activatedChanged, this, &DatalinkSerialRemotes::save);
+    connect(c->f_remove,
+            &Fact::triggered,
+            this,
+            &DatalinkSerialRemotes::onConnectionRemoveTriggered);
+
+    updateStatus();
+    return c;
+}
+
+void DatalinkSerialRemotes::onConnectionActiveChanged()
+{
+    auto c = qobject_cast<DatalinkSerialRemote *>(sender());
+    updateStatus();
+}
+
+void DatalinkSerialRemotes::onConnectionRemoveTriggered()
+{
+    save();
+    updateStatus();
+}
+
+void DatalinkSerialRemotes::onConnectTriggered()
+{
+    createConnection(f_host->text(), f_port->value().toInt());
+    save();
+}

--- a/src/lib/ApxGcs/Datalink/DatalinkSerialRemotes.h
+++ b/src/lib/ApxGcs/Datalink/DatalinkSerialRemotes.h
@@ -1,0 +1,54 @@
+/*
+ * APX Autopilot project <http://docs.uavos.com>
+ *
+ * Copyright (c) 2003-2020, Aliaksei Stratsilatau <sa@uavos.com>
+ * All rights reserved
+ *
+ * This file is part of APX Ground Control.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include "DatalinkConnection.h"
+
+class Datalink;
+class DatalinkSerialRemote;
+
+class DatalinkSerialRemotes : public Fact
+{
+    Q_OBJECT
+
+public:
+    explicit DatalinkSerialRemotes(Datalink *datalink);
+
+    Fact *f_add = nullptr;
+    Fact *f_host = nullptr;
+    Fact *f_port = nullptr;
+    Fact *f_connect = nullptr;
+    Fact *f_list = nullptr;
+
+private:
+    Datalink *m_datalink = nullptr;
+
+    void updateStatus();
+    void load();
+    void save();
+    DatalinkSerialRemote *createConnection(const QString &host, int port);
+
+private slots:
+    void onConnectTriggered();
+    void onConnectionActiveChanged();
+    void onConnectionRemoveTriggered();
+};


### PR DESCRIPTION
With this PR we establish datalink directly with server, without additional ethernet->serial converters.